### PR TITLE
Fix 1password

### DIFF
--- a/kubernetes/apps/external-secrets/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
 components:
   # - ../../flux/components/alerts # todo: reenable
   - ../../flux/components/namespace
-  #- ../../flux/components/sops
+  - ../../flux/components/sops

--- a/kubernetes/flux/components/sops/kustomization.yaml
+++ b/kubernetes/flux/components/sops/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./secret.sops.yaml

--- a/kubernetes/flux/components/sops/secret.sops.yaml
+++ b/kubernetes/flux/components/sops/secret.sops.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.1-standalone-strict/secret-v1.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sops-age
+stringData:
+  age.agekey: ENC[AES256_GCM,data:wkwQKvqfYtnyj5Tf5HCTZJaAqBfeDVHxZ1nHlH1Qge5fYSxq7XUcsoQ8LNIWkSOitmQG6K95AJ6LMx7NGAontzRQNiI48FJrXhg=,iv:ZfFgT0ChPG+8ZQaDP+np+SU0ISkh1cTtn2cfkHEWUSU=,tag:mL9Lz+9L9d9QQ8L252pPrA==,type:str]
+sops:
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1s2nhgfwzfejn69nyctjglkwdd5h0wyg8t8ln4m2fmhdnprn28v0q0mmp2h
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmQW5CbTNvZ2dGbzJHdWUw
+        R2duZjkvR2dwbm9lS2IvQlJUTkhURDN4TmxrCmhIWlpHTGQ3ZkppaDNrbEg5UEI1
+        US8vRGdkUUNSMDVTMFJ6RENTSHU5T0EKLS0tIHRIK2RPZ1NhYWE2aGhSZ0RER0tU
+        VWtxZjFGZ3hZcm43cWhRVmdXZkhkYzgK9j3c1il/hHvS1jfcbHXQA1VDay/BNxrH
+        QKjYXCv9WS3V9AoxzUF8u0gmN21G7NQeprE/waMS3JNzwrd1ma4BFQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2025-02-03T12:05:56Z"
+  mac: ENC[AES256_GCM,data:8EzcWaJ8EwM5hsGpz7SihRf7v4qfIabrohKxp4QPwE4kztYuu3Ne6T8ETQpeM8IKkJG3qarRnWsYxdaAs87bh/XemRR+g/e11BZOBsTI/mAcgG4HdNjRKveRrOpwxUn4TFen+e+iEZ5gqtzOFn0vaMYQ2VCoOsImQ4mdm126u/A=,iv:j2JRfM42yyF7aWgM9k0sH15GV7BcWcjfZ4fi+Xhomrw=,tag:ciHovPfXEEiEB1/E35ANmw==,type:str]
+  pgp: []
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.9.4


### PR DESCRIPTION
By adding age-key to secret to fix


```
$ flux get all -A --status-selector ready=false

NAMESPACE       NAME    REVISION        SUSPENDED       READY   MESSAGE

NAMESPACE       NAME    REVISION        SUSPENDED       READY   MESSAGE

NAMESPACE       NAME    REVISION        SUSPENDED       READY   MESSAGE

NAMESPACE       NAME    REVISION        SUSPENDED       READY   MESSAGE

NAMESPACE               NAME                            REVISION        SUSPENDED       READY   MESSAGE
external-secrets        kustomization/external-secrets                  False           False   secrets "sops-age" not found
external-secrets        kustomization/onepassword                       False           False   secrets "sops-age" not found
external-secrets        kustomization/onepassword-store                 False           False   dependency 'external-secrets/onepassword' is not ready
kube-system             kustomization/coredns                           False           False   secrets "sops-age" not found

NAMESPACE       NAME    SUSPENDED       READY   MESSAGE

```