### PR TITLE
fix(unifi): mount certs inside service

### DIFF
--- a/kubernetes/apps/default/unifi/app/backendtlspolicy.yaml
+++ b/kubernetes/apps/default/unifi/app/backendtlspolicy.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://schemas.tholinka.dev/gateway.networking.k8s.io/backendtlspolicy_v1alpha3.json
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: unifi-backend-tls
+  namespace: default
+spec:
+  targetRefs:
+    - group: ''
+      kind: Service
+      name: unifi
+      sectionName: https
+  validation:
+    wellKnownCACertificates: System
+    hostname: unifi.local.martinbjeldbak.com

--- a/kubernetes/apps/default/unifi/app/certificate.yaml
+++ b/kubernetes/apps/default/unifi/app/certificate.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://schemas.tholinka.dev/cert-manager.io/certificate_v1.json
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: martinbjeldbak-com-unifi
+spec:
+  secretName: martinbjeldbak-com-unifi
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: unifi.local.martinbjeldbak.com
+  dnsNames:
+    - 'unifi.local.martinbjeldbak.com'
+  keystores:
+    jks:
+      create: true
+      alias: unifi
+      password: aircontrolenterprise

--- a/kubernetes/apps/default/unifi/app/certificate.yaml
+++ b/kubernetes/apps/default/unifi/app/certificate.yaml
@@ -5,7 +5,7 @@ kind: Certificate
 metadata:
   name: martinbjeldbak-com-unifi
 spec:
-  secretName: martinbjeldbak-com-unifi
+  secretName: martinbjeldbak-com-unifi-tls
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer

--- a/kubernetes/apps/default/unifi/app/helmrelease.yaml
+++ b/kubernetes/apps/default/unifi/app/helmrelease.yaml
@@ -59,13 +59,13 @@ spec:
         # See https://github.com/jacobalberty/unifi-docker
         ports:
           http:
-            port: 8443 # web interface + API
+            port: &port 8443 # web interface + API
             protocol: HTTPS
           controller:
             port: 8080
             protocol: TCP
           portal-http:
-            port: &port 8880 # http portal
+            port: 8880 # http portal
             protocol: HTTP
           portal-https:
             enabled: false
@@ -95,6 +95,24 @@ spec:
           - backendRefs:
               - identifier: app
                 port: *port
+            timeouts:
+              request: 0s  # websocket, never time out
+              backendRequest: 0s  # websocket, never time out
     persistence:
       unifi:
         existingClaim: unifi-v3
+      cert:
+        type: secret
+        name: 'martinbjeldbak-com-unifi-tls'
+        advancedMounts:
+          unifi:
+            app:
+              - path: /unifi/cert/cert.pem
+                subPath: tls.crt
+                readOnly: true
+              - path: /unifi/cert/privkey.pem
+                subPath: tls.key
+                readOnly: true
+              - path: /unifi/data/keystore
+                subPath: keystore.jks
+                readOnly: false

--- a/kubernetes/apps/default/unifi/app/kustomization.yaml
+++ b/kubernetes/apps/default/unifi/app/kustomization.yaml
@@ -3,5 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./pvc.yaml
+  - ./backendtlspolicy.yaml
+  - ./certificate.yaml
   - ./helmrelease.yaml
+  - ./pushsecret.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/default/unifi/app/pushsecret.yaml
+++ b/kubernetes/apps/default/unifi/app/pushsecret.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://schemas.tholinka.dev/external-secrets.io/pushsecret_v1alpha1.json
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: lets-encrypt-unifi
+spec:
+  secretStoreRefs:
+    - name: onepassword
+      kind: ClusterSecretStore
+  selector:
+    secret:
+      name: martinbjeldbak-com-unifi-tls
+  template:
+    engineVersion: v2
+    data:
+      keystore.jks: '{{ index . "keystore.jks" | b64enc }}'
+      tls.crt: '{{ index . "tls.crt" | b64enc }}'
+      tls.key: '{{ index . "tls.key" | b64enc }}'
+  data:
+    - match:
+        secretKey: &key keystore.jks
+        remoteRef:
+          remoteKey: martinbjeldbak-com-unifi-tls
+          property: *key
+    - match:
+        secretKey: &key tls.crt
+        remoteRef:
+          remoteKey: martinbjeldbak-com-unifi-tls
+          property: *key
+    - match:
+        secretKey: &key tls.key
+        remoteRef:
+          remoteKey: martinbjeldbak-com-unifi-tls
+          property: *key


### PR DESCRIPTION
Following https://github.com/tajinder400/home-ops/commit/e9889f6e95aef2a8b7abb5beede01ef0bd947210

Unifi controller not accessible after migrating to HTTPRoute and Gateway API