### PR TITLE
Add manual HTTPRoute for immich

### DIFF
--- a/kubernetes/apps/default/immich/app/httproute.yaml
+++ b/kubernetes/apps/default/immich/app/httproute.yaml
@@ -11,6 +11,9 @@ spec:
       sectionName: https
   rules:
     - matches:
+        - path:
+            type: PathPrefix
+            value: /
       backendRefs:
         - name: immich-server
           port: 2283

--- a/kubernetes/apps/default/immich/app/httproute.yaml
+++ b/kubernetes/apps/default/immich/app/httproute.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute # NOTE: remove when https://github.com/immich-app/immich-charts/issues/165 resolved
+metadata:
+  name: immich
+spec:
+  hostnames: ["immich.local.martinbjeldbak.com"]
+  parentRefs:
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - matches:
+      backendRefs:
+        - name: immich-server
+          port: 2283

--- a/kubernetes/apps/default/immich/app/kustomization.yaml
+++ b/kubernetes/apps/default/immich/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./pvc.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml


### PR DESCRIPTION
Until https://github.com/immich-app/immich-charts/issues/165 resolved

Since switching to Gateway API in #457, immich has been inaccessible. And just updated to v1.133.1 in #486 so want to check