### PR TITLE
chore: bump all postgres versions to be similar

### DIFF
--- a/kubernetes/apps/default/authentik/database/cluster.yaml
+++ b/kubernetes/apps/default/authentik/database/cluster.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   instances: 1
   # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.2-34@sha256:61d2b391e3e324d05edc6c65c555989a7c544ddb72ef271b3abd4a35b57942b1
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5-standard-bookworm@sha256:8bcc3eb5b0b2dd7ad91c3c57eadc0df37148f28be16fc8062ed5eb29a2a4a4b7
   bootstrap:  # following https://cloudnative-pg.io/documentation/1.25/bootstrap/
     initdb:
       database: authentik

--- a/kubernetes/apps/default/dawarich/database/cluster.yaml
+++ b/kubernetes/apps/default/dawarich/database/cluster.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   instances: 1
   # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
-  imageName: ghcr.io/cloudnative-pg/postgis:17
-  bootstrap:  # following https://cloudnative-pg.io/documentation/1.25/bootstrap/
+  imageName: ghcr.io/cloudnative-pg/postgis:17-3.5@sha256:f429306b52e07d013e13cdc78fe987e29f81ed7e3e115784c12073f598904786
+  bootstrap:
     initdb:
       database: dawarich_development
       owner: dawarich

--- a/kubernetes/apps/default/paperless/database/cluster.yaml
+++ b/kubernetes/apps/default/paperless/database/cluster.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   instances: 1
   # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.4-7@sha256:84bc07f2c73f4f5473774e6502c5b1ca2d11ae87e4ca5445c646c0d80d2792ec
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5-standard-bookworm@sha256:8bcc3eb5b0b2dd7ad91c3c57eadc0df37148f28be16fc8062ed5eb29a2a4a4b7
   bootstrap:  # following https://cloudnative-pg.io/documentation/1.25/bootstrap/
     initdb:
       database: paperless

--- a/kubernetes/apps/default/romm/database/cluster.yaml
+++ b/kubernetes/apps/default/romm/database/cluster.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   instances: 1
   # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.4-9@sha256:507376cb4fb29498d767fbc1ed5c3a9ee6099136d3519be69bdb463b92b5120e
-  bootstrap:  # following https://cloudnative-pg.io/documentation/1.25/bootstrap/
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5-standard-bookworm@sha256:8bcc3eb5b0b2dd7ad91c3c57eadc0df37148f28be16fc8062ed5eb29a2a4a4b7
+  bootstrap:
     initdb:
       database: romm
       owner: romm

--- a/kubernetes/apps/default/speedtest-tracker/database/cluster.yaml
+++ b/kubernetes/apps/default/speedtest-tracker/database/cluster.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   instances: 1
   # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.2-34@sha256:61d2b391e3e324d05edc6c65c555989a7c544ddb72ef271b3abd4a35b57942b1
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.5-standard-bookworm@sha256:8bcc3eb5b0b2dd7ad91c3c57eadc0df37148f28be16fc8062ed5eb29a2a4a4b7
   bootstrap:  # following https://cloudnative-pg.io/documentation/1.25/bootstrap/
     initdb:
       database: speedtest-tracker


### PR DESCRIPTION
Somehow Renovate not picking up on these versions