### PR TITLE
feat: add barman cloud plugin manifst as crd

### DIFF
--- a/kubernetes/apps/cnpg-system/cloudnative-pg/app/crds.yaml
+++ b/kubernetes/apps/cnpg-system/cloudnative-pg/app/crds.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/gitrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: barman-cloud-crd
+spec:
+  interval: 30m
+  url: https://github.com/cloudnative-pg/plugin-barman-cloud
+  ref:
+    tag: v0.4.0
+  ignore: |
+    # exclude
+    /*
+    # include
+    !manifest.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: barman-cloud-crd
+spec:
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: barman-cloud-crd
+  wait: true
+  interval: 15m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/cnpg-system/cloudnative-pg/app/helmrelease.yaml
+++ b/kubernetes/apps/cnpg-system/cloudnative-pg/app/helmrelease.yaml
@@ -33,5 +33,6 @@ spec:
       retries: 3
   values:
     monitoring:
+      podMonitorEnabled: true
       grafanaDashboard:
         create: true

--- a/kubernetes/apps/cnpg-system/cloudnative-pg/app/kustomization.yaml
+++ b/kubernetes/apps/cnpg-system/cloudnative-pg/app/kustomization.yaml
@@ -3,4 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./crds.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
Following https://cloudnative-pg.io/plugin-barman-cloud/docs/usage/, barman cloud plugin is now separated in cloudnative-pg 0.26.0