### PR TITLE
feat: migrate to cloudnative-pg backup plugin

### DIFF
--- a/kubernetes/apps/default/authentik/database/backup.yaml
+++ b/kubernetes/apps/default/authentik/database/backup.yaml
@@ -8,3 +8,5 @@ spec:
   backupOwnerReference: self
   cluster:
     name: authentik-database-v4
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/default/authentik/database/cluster.yaml
+++ b/kubernetes/apps/default/authentik/database/cluster.yaml
@@ -27,20 +27,8 @@ spec:
   monitoring:
     enablePodMonitor: true
   enableSuperuserAccess: false
-  backup:
-    retentionPolicy: 30d
-    barmanObjectStore:
-      data:
-        compression: bzip2
-      wal:
-        compression: bzip2
-        maxParallel: 8
-      destinationPath: "s3://home-ops-postgres-backups/authentik/"
-      endpointURL: "https://s3.eu-central-003.backblazeb2.com"
-      s3Credentials:
-        accessKeyId:
-          name: authentik-backblaze-secret
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: authentik-backblaze-secret
-          key: ACCESS_SECRET_KEY
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: b2-authentik

--- a/kubernetes/apps/default/authentik/database/kustomization.yaml
+++ b/kubernetes/apps/default/authentik/database/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./cluster.yaml
   - ./backup.yaml
+  - ./objectstore.yaml

--- a/kubernetes/apps/default/authentik/database/objectstore.yaml
+++ b/kubernetes/apps/default/authentik/database/objectstore.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: b2-authentik
+spec:
+  retentionPolicy: 30d
+  configuration:
+    data:
+      compression: bzip2
+    wal:
+      compression: bzip2
+      maxParallel: 8
+    destinationPath: "s3://home-ops-postgres-backups/authentik/"
+    endpointURL: "https://s3.eu-central-003.backblazeb2.com"
+    s3Credentials:
+      accessKeyId:
+        name: authentik-backblaze-secret
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: authentik-backblaze-secret
+        key: ACCESS_SECRET_KEY

--- a/kubernetes/apps/default/dawarich/database/backup.yaml
+++ b/kubernetes/apps/default/dawarich/database/backup.yaml
@@ -8,3 +8,5 @@ spec:
   backupOwnerReference: self
   cluster:
     name: dawarich-database
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/default/dawarich/database/cluster.yaml
+++ b/kubernetes/apps/default/dawarich/database/cluster.yaml
@@ -55,13 +55,3 @@ spec:
         secretAccessKey:
           name: dawarich-backblaze-secret
           key: ACCESS_SECRET_KEY
-  # externalClusters:
-  #   - name: docker-dawarich
-  #     connectionParameters:
-  #       host: alderaan.internal
-  #       port: "5433"
-  #       user: dawarich
-  #       dbname: dawarich_development
-  #     password:
-  #       name: dawarich-cluster-credentials-secret
-  #       key: password

--- a/kubernetes/apps/default/dawarich/database/cluster.yaml
+++ b/kubernetes/apps/default/dawarich/database/cluster.yaml
@@ -19,12 +19,6 @@ spec:
         - CREATE EXTENSION postgis_topology;
         - CREATE EXTENSION fuzzystrmatch;
         - CREATE EXTENSION postgis_tiger_geocoder;
-      # import:
-      #   type: microservice
-      #   databases:
-      #     - dawarich_development
-      #   source:
-      #     externalCluster: docker-dawarich
   storage:
     size: 5Gi
     pvcTemplate:
@@ -38,20 +32,8 @@ spec:
   monitoring:
     enablePodMonitor: true
   enableSuperuserAccess: false
-  backup:
-    retentionPolicy: 30d
-    barmanObjectStore:
-      data:
-        compression: bzip2
-      wal:
-        compression: bzip2
-        maxParallel: 8
-      destinationPath: "s3://home-ops-postgres-backups/dawarich/"
-      endpointURL: "https://s3.eu-central-003.backblazeb2.com"
-      s3Credentials:
-        accessKeyId:
-          name: dawarich-backblaze-secret
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: dawarich-backblaze-secret
-          key: ACCESS_SECRET_KEY
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: b2-dawarich

--- a/kubernetes/apps/default/dawarich/database/kustomization.yaml
+++ b/kubernetes/apps/default/dawarich/database/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./cluster.yaml
   - ./backup.yaml
+  - ./objectstore.yaml

--- a/kubernetes/apps/default/dawarich/database/objectstore.yaml
+++ b/kubernetes/apps/default/dawarich/database/objectstore.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: b2-dawarich
+spec:
+  retentionPolicy: 30d
+  configuration:
+    data:
+      compression: bzip2
+    wal:
+      compression: bzip2
+      maxParallel: 8
+    destinationPath: "s3://home-ops-postgres-backups/dawarich/"
+    endpointURL: "https://s3.eu-central-003.backblazeb2.com"
+    s3Credentials:
+      accessKeyId:
+        name: dawarich-backblaze-secret
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: dawarich-backblaze-secret
+        key: ACCESS_SECRET_KEY

--- a/kubernetes/apps/default/immich/database/backup.yaml
+++ b/kubernetes/apps/default/immich/database/backup.yaml
@@ -8,3 +8,5 @@ spec:
   backupOwnerReference: self
   cluster:
     name: immich-database-v2
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/default/immich/database/cluster.yaml
+++ b/kubernetes/apps/default/immich/database/cluster.yaml
@@ -44,4 +44,4 @@ spec:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true
       parameters:
-        barmanObjectName: b2-romm
+        barmanObjectName: b2-immich

--- a/kubernetes/apps/default/immich/database/cluster.yaml
+++ b/kubernetes/apps/default/immich/database/cluster.yaml
@@ -40,20 +40,8 @@ spec:
   monitoring:
     enablePodMonitor: true
   enableSuperuserAccess: false
-  backup:
-    retentionPolicy: 30d
-    barmanObjectStore:
-      data:
-        compression: bzip2
-      wal:
-        compression: bzip2
-        maxParallel: 8
-      destinationPath: "s3://home-ops-postgres-backups/immich/"
-      endpointURL: "https://s3.eu-central-003.backblazeb2.com"
-      s3Credentials:
-        accessKeyId:
-          name: immich-backblaze-secret
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: immich-backblaze-secret
-          key: ACCESS_SECRET_KEY
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: b2-romm

--- a/kubernetes/apps/default/immich/database/kustomization.yaml
+++ b/kubernetes/apps/default/immich/database/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./backup.yaml
   - ./cluster.yaml
+  - ./objectstore.yaml

--- a/kubernetes/apps/default/immich/database/objectstore.yaml
+++ b/kubernetes/apps/default/immich/database/objectstore.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: b2-immich
+spec:
+  retentionPolicy: 30d
+  configuration:
+    data:
+      compression: bzip2
+    wal:
+      compression: bzip2
+      maxParallel: 8
+    destinationPath: "s3://home-ops-postgres-backups/immich/"
+    endpointURL: "https://s3.eu-central-003.backblazeb2.com"
+    s3Credentials:
+      accessKeyId:
+        name: immich-backblaze-secret
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: immich-backblaze-secret
+        key: ACCESS_SECRET_KEY

--- a/kubernetes/apps/default/paperless/database/backup.yaml
+++ b/kubernetes/apps/default/paperless/database/backup.yaml
@@ -8,3 +8,5 @@ spec:
   backupOwnerReference: self
   cluster:
     name: paperless-database
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/default/paperless/database/cluster.yaml
+++ b/kubernetes/apps/default/paperless/database/cluster.yaml
@@ -27,20 +27,8 @@ spec:
   monitoring:
     enablePodMonitor: true
   enableSuperuserAccess: false
-  backup:
-    retentionPolicy: 30d
-    barmanObjectStore:
-      data:
-        compression: bzip2
-      wal:
-        compression: bzip2
-        maxParallel: 8
-      destinationPath: "s3://home-ops-postgres-backups/paperless/"
-      endpointURL: "https://s3.eu-central-003.backblazeb2.com"
-      s3Credentials:
-        accessKeyId:
-          name: paperless-backblaze-secret
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: paperless-backblaze-secret
-          key: ACCESS_SECRET_KEY
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: b2-paperless

--- a/kubernetes/apps/default/paperless/database/kustomization.yaml
+++ b/kubernetes/apps/default/paperless/database/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./cluster.yaml
   - ./backup.yaml
+  - ./objectstore.yaml

--- a/kubernetes/apps/default/paperless/database/objectstore.yaml
+++ b/kubernetes/apps/default/paperless/database/objectstore.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: b2-paperless
+spec:
+  retentionPolicy: 30d
+  configuration:
+    data:
+      compression: bzip2
+    wal:
+      compression: bzip2
+      maxParallel: 8
+    destinationPath: "s3://home-ops-postgres-backups/paperless/"
+    endpointURL: "https://s3.eu-central-003.backblazeb2.com"
+    s3Credentials:
+      accessKeyId:
+        name: paperless-backblaze-secret
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: paperless-backblaze-secret
+        key: ACCESS_SECRET_KEY

--- a/kubernetes/apps/default/romm/database/backup.yaml
+++ b/kubernetes/apps/default/romm/database/backup.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
@@ -8,3 +9,6 @@ spec:
   backupOwnerReference: self
   cluster:
     name: romm-database
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/default/romm/database/cluster.yaml
+++ b/kubernetes/apps/default/romm/database/cluster.yaml
@@ -27,20 +27,8 @@ spec:
   monitoring:
     enablePodMonitor: true
   enableSuperuserAccess: false
-  backup:
-    retentionPolicy: 30d
-    barmanObjectStore:
-      data:
-        compression: bzip2
-      wal:
-        compression: bzip2
-        maxParallel: 8
-      destinationPath: "s3://home-ops-postgres-backups/romm/"
-      endpointURL: "https://s3.eu-central-003.backblazeb2.com"
-      s3Credentials:
-        accessKeyId:
-          name: romm-backblaze-secret
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: romm-backblaze-secret
-          key: ACCESS_SECRET_KEY
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: b2-romm

--- a/kubernetes/apps/default/romm/database/kustomization.yaml
+++ b/kubernetes/apps/default/romm/database/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./cluster.yaml
   - ./backup.yaml
+  - ./objectstore.yaml

--- a/kubernetes/apps/default/romm/database/objectstore.yaml
+++ b/kubernetes/apps/default/romm/database/objectstore.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: b2-romm
+spec:
+  retentionPolicy: 30d
+  configuration:
+    data:
+      compression: bzip2
+    wal:
+      compression: bzip2
+      maxParallel: 8
+    destinationPath: "s3://home-ops-postgres-backups/romm/"
+    endpointURL: "https://s3.eu-central-003.backblazeb2.com"
+    s3Credentials:
+      accessKeyId:
+        name: romm-backblaze-secret
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: romm-backblaze-secret
+        key: ACCESS_SECRET_KEY

--- a/kubernetes/apps/default/speedtest-tracker/database/backup.yaml
+++ b/kubernetes/apps/default/speedtest-tracker/database/backup.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/scheduledbackup_v1.json
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: speedtest-tracker-backup
+spec:
+  schedule: "0 0 0 * * *"  # midnight
+  backupOwnerReference: self
+  cluster:
+    name: speedtest-tracker-database
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/default/speedtest-tracker/database/cluster.yaml
+++ b/kubernetes/apps/default/speedtest-tracker/database/cluster.yaml
@@ -27,20 +27,8 @@ spec:
   monitoring:
     enablePodMonitor: true
   enableSuperuserAccess: false
-  backup:
-    retentionPolicy: 30d
-    barmanObjectStore:
-      data:
-        compression: bzip2
-      wal:
-        compression: bzip2
-        maxParallel: 8
-      destinationPath: "s3://home-ops-postgres-backups/speedtest-tracker/"
-      endpointURL: "https://s3.eu-central-003.backblazeb2.com"
-      s3Credentials:
-        accessKeyId:
-          name: speedtest-tracker-backblaze-secret
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: speedtest-tracker-backblaze-secret
-          key: ACCESS_SECRET_KEY
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: b2-speedtest-tracker

--- a/kubernetes/apps/default/speedtest-tracker/database/kustomization.yaml
+++ b/kubernetes/apps/default/speedtest-tracker/database/kustomization.yaml
@@ -3,5 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./backup.yaml
   - ./externalsecret.yaml
   - ./cluster.yaml
+  - ./objectstore.yaml

--- a/kubernetes/apps/default/speedtest-tracker/database/objectstore.yaml
+++ b/kubernetes/apps/default/speedtest-tracker/database/objectstore.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: b2-speedtest-tracker
+spec:
+  retentionPolicy: 30d
+  configuration:
+    data:
+      compression: bzip2
+    wal:
+      compression: bzip2
+      maxParallel: 8
+    destinationPath: "s3://home-ops-postgres-backups/speedtest-tracker/"
+    endpointURL: "https://s3.eu-central-003.backblazeb2.com"
+    s3Credentials:
+      accessKeyId:
+        name: speedtest-tracker-backblaze-secret
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: speedtest-tracker-backblaze-secret
+        key: ACCESS_SECRET_KEY


### PR DESCRIPTION
#502 added the CRDs, this PR replaces all in-place barman backups with the new plugin-based ones, following https://cloudnative-pg.io/plugin-barman-cloud/docs/migration/