### PR TITLE
feat: enable bgp peering with OPNSense router

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
@@ -12,7 +12,7 @@ bpf:
   hostLegacyRouting: true
 bpfClockProbe: true
 bgpControlPlane:
-  enabled: false
+  enabled: true
 cgroup:
   automount:
     enabled: false

--- a/kubernetes/apps/kube-system/cilium/app/networks.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networks.yaml
@@ -21,3 +21,51 @@ spec:
   nodeSelector:
     matchLabels:
       kubernetes.io/os: linux
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumbgpadvertisement_v2alpha1.json
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPAdvertisement
+metadata:
+  name: l3-bgp-advertisement
+  labels:
+    advertise: bgp
+spec:
+  advertisements:
+    - advertisementType: Service
+      service:
+        addresses: ["LoadBalancerIP"]
+      selector:
+        matchExpressions:
+          - { key: somekey, operator: NotIn, values: ["never-used-value"] }
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumbgppeerconfig_v2alpha1.json
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPPeerConfig
+metadata:
+  name: l3-bgp-peer-config
+spec:
+  families:
+    - afi: ipv4
+      safi: unicast
+      advertisements:
+        matchLabels:
+          advertise: bgp
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumbgpclusterconfig_v2alpha1.json
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPClusterConfig
+metadata:
+  name: l3-bgp-cluster-config
+spec:
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/os: linux
+  bgpInstances:
+    - name: cilium
+      localASN: 64514
+      peers:
+        - name: opnsense
+          peerASN: 64513
+          peerAddress: 192.168.1.1
+          peerConfigRef:
+            name: l3-bgp-peer-config

--- a/kubernetes/apps/kube-system/cilium/gateway/internal.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/internal.yaml
@@ -8,9 +8,9 @@ spec:
   gatewayClassName: cilium
   addresses:
     - type: IPAddress
-      value: 192.168.1.121
+      value: 192.168.1.120
     - type: IPAddress
-      value: ::ffff:192.168.1.121
+      value: ::ffff:192.168.1.120
   listeners:
     - name: http
       protocol: HTTP


### PR DESCRIPTION
https://dickingwithdocker.com/posts/using-bgp-to-integrate-cilium-with-opnsense/

https://dickingwithdocker.com/posts/update-using-bgp-to-integrate-cilium-with-opnsense/